### PR TITLE
Disable RTS/CTS handshake by default

### DIFF
--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -13,7 +13,7 @@ const regexFilter = "^(cu|tty)\\..*"
 
 // termios manipulation functions
 
-var baudrateMap = map[int]int{
+var baudrateMap = map[int]uint{
 	0:      syscall.B9600, // Default to 9600
 	50:     syscall.B50,
 	75:     syscall.B75,
@@ -35,7 +35,7 @@ var baudrateMap = map[int]int{
 	230400: syscall.B230400,
 }
 
-var databitsMap = map[int]int{
+var databitsMap = map[int]uint{
 	0: syscall.CS8, // Default to 8 bits
 	5: syscall.CS5,
 	6: syscall.CS6,
@@ -43,13 +43,13 @@ var databitsMap = map[int]int{
 	8: syscall.CS8,
 }
 
-const tcCMSPAR int = 0 // may be CMSPAR or PAREXT
-const tcIUCLC int = 0
+const tcCMSPAR uint = 0 // may be CMSPAR or PAREXT
+const tcIUCLC uint = 0
 
-const tcCCTS_OFLOW int = 0x00010000
-const tcCRTS_IFLOW int = 0x00020000
+const tcCCTS_OFLOW uint = 0x00010000
+const tcCRTS_IFLOW uint = 0x00020000
 
-const tcCRTSCTS int = (tcCCTS_OFLOW | tcCRTS_IFLOW)
+const tcCRTSCTS uint = (tcCCTS_OFLOW | tcCRTS_IFLOW)
 
 // syscall wrappers
 

--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -46,6 +46,11 @@ var databitsMap = map[int]int{
 const tcCMSPAR int = 0 // may be CMSPAR or PAREXT
 const tcIUCLC int = 0
 
+const tcCCTS_OFLOW int = 0x00010000
+const tcCRTS_IFLOW int = 0x00020000
+
+const tcCRTSCTS int = (tcCCTS_OFLOW | tcCRTS_IFLOW)
+
 // syscall wrappers
 
 //sys ioctl(fd int, req uint64, data uintptr) (err error)

--- a/serial_darwin_386.go
+++ b/serial_darwin_386.go
@@ -6,6 +6,6 @@
 
 package serial // import "go.bug.st/serial.v1"
 
-func termiosMask(data int) uint32 {
+func termiosMask(data uint) uint32 {
 	return uint32(data)
 }

--- a/serial_darwin_amd64.go
+++ b/serial_darwin_amd64.go
@@ -8,6 +8,6 @@ package serial // import "go.bug.st/serial.v1"
 
 // termios manipulation functions
 
-func termiosMask(data int) uint64 {
+func termiosMask(data uint) uint64 {
 	return uint64(data)
 }

--- a/serial_freebsd.go
+++ b/serial_freebsd.go
@@ -13,7 +13,7 @@ const regexFilter = "^(cu|tty)\\..*"
 
 // termios manipulation functions
 
-var baudrateMap = map[int]int{
+var baudrateMap = map[int]uint{
 	0:      syscall.B9600, // Default to 9600
 	50:     syscall.B50,
 	75:     syscall.B75,
@@ -37,7 +37,7 @@ var baudrateMap = map[int]int{
 	921600: syscall.B921600,
 }
 
-var databitsMap = map[int]int{
+var databitsMap = map[int]uint{
 	0: syscall.CS8, // Default to 8 bits
 	5: syscall.CS5,
 	6: syscall.CS6,
@@ -45,15 +45,15 @@ var databitsMap = map[int]int{
 	8: syscall.CS8,
 }
 
-const tcCMSPAR int = 0 // may be CMSPAR or PAREXT
-const tcIUCLC int = 0
+const tcCMSPAR uint = 0 // may be CMSPAR or PAREXT
+const tcIUCLC uint = 0
 
-const tcCCTS_OFLOW int = 0x00010000
-const tcCRTS_IFLOW int = 0x00020000
+const tcCCTS_OFLOW uint = 0x00010000
+const tcCRTS_IFLOW uint = 0x00020000
 
-const tcCRTSCTS int = tcCCTS_OFLOW
+const tcCRTSCTS uint = tcCCTS_OFLOW
 
-func termiosMask(data int) uint32 {
+func termiosMask(data uint) uint32 {
 	return uint32(data)
 }
 

--- a/serial_freebsd.go
+++ b/serial_freebsd.go
@@ -48,6 +48,11 @@ var databitsMap = map[int]int{
 const tcCMSPAR int = 0 // may be CMSPAR or PAREXT
 const tcIUCLC int = 0
 
+const tcCCTS_OFLOW int = 0x00010000
+const tcCRTS_IFLOW int = 0x00020000
+
+const tcCRTSCTS int = tcCCTS_OFLOW
+
 func termiosMask(data int) uint32 {
 	return uint32(data)
 }

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -58,6 +58,8 @@ var databitsMap = map[int]int{
 const tcCMSPAR int = 0 // may be CMSPAR or PAREXT
 const tcIUCLC = syscall.IUCLC
 
+const tcCRTSCTS int = 0x80000000
+
 func termiosMask(data int) uint32 {
 	return uint32(data)
 }

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -13,7 +13,7 @@ const regexFilter = "(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO)[0-9]{1,3}"
 
 // termios manipulation functions
 
-var baudrateMap = map[int]int{
+var baudrateMap = map[int]uint{
 	0:       syscall.B9600, // Default to 9600
 	50:      syscall.B50,
 	75:      syscall.B75,
@@ -47,7 +47,7 @@ var baudrateMap = map[int]int{
 	4000000: syscall.B4000000,
 }
 
-var databitsMap = map[int]int{
+var databitsMap = map[int]uint{
 	0: syscall.CS8, // Default to 8 bits
 	5: syscall.CS5,
 	6: syscall.CS6,
@@ -55,12 +55,12 @@ var databitsMap = map[int]int{
 	8: syscall.CS8,
 }
 
-const tcCMSPAR int = 0 // may be CMSPAR or PAREXT
+const tcCMSPAR uint = 0 // may be CMSPAR or PAREXT
 const tcIUCLC = syscall.IUCLC
 
-const tcCRTSCTS int = 0x80000000
+const tcCRTSCTS uint = 0x80000000
 
-func termiosMask(data int) uint32 {
+func termiosMask(data uint) uint32 {
 	return uint32(data)
 }
 

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -203,6 +203,9 @@ func setRawMode(settings *syscall.Termios) {
 	// Set local mode
 	settings.Cflag |= termiosMask(syscall.CREAD | syscall.CLOCAL)
 
+	// Explicitly disable RTS/CTS flow control
+	settings.Cflag &= ^termiosMask(tcCRTSCTS)
+
 	// Set raw mode
 	settings.Lflag &= ^termiosMask(syscall.ICANON | syscall.ECHO | syscall.ECHOE | syscall.ECHOK |
 		syscall.ECHONL | syscall.ECHOCTL | syscall.ECHOPRT | syscall.ECHOKE | syscall.ISIG | syscall.IEXTEN)

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -143,7 +143,7 @@ func setTermSettingsBaudrate(speed int, settings *syscall.Termios) error {
 		return &PortError{code: InvalidSpeed}
 	}
 	// revert old baudrate
-	BAUDMASK := 0
+	var BAUDMASK uint
 	for _, rate := range baudrateMap {
 		BAUDMASK |= rate
 	}


### PR DESCRIPTION
This should disable RTS/CTS flow control.

The constant `syscall.CRTSCTS` is not defined in golang, so I had to do a bit of research to find its value for all unix flavors.

Hopefully this fix #3, @jcw may you test it? you should need to patch only `serial_darwin.go` and `serial_unix.go` to try.