### PR TITLE
Enumerator: Fixed go:generate comment

### DIFF
--- a/enumerator/enumerator.go
+++ b/enumerator/enumerator.go
@@ -6,7 +6,7 @@
 
 package enumerator // import "go.bug.st/serial.v1/enumerator"
 
-//go:generate go run ../extras/mksyscall_windows.go -output syscall_windows.go usb_windows.go
+//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -output syscall_windows.go usb_windows.go
 
 // PortDetails contains detailed information about USB serial port.
 // Use GetDetailedPortsList function to retrieve it.


### PR DESCRIPTION
It pointing to mksyscal_windows.go in local folder which already removed