### PR TITLE
Product in PortDetails struct

### DIFF
--- a/enumerator/enumerator.go
+++ b/enumerator/enumerator.go
@@ -18,7 +18,7 @@ type PortDetails struct {
 	SerialNumber string
 
 	// Manufacturer string
-	// Product      string
+	Product      string
 }
 
 // GetDetailedPortsList retrieve ports details like USB VID/PID.


### PR DESCRIPTION
un-commented Product member of the struct PortDetails. This goes with the pull request "completed retrievePortDetailsFromDevInfo #40". Apologies for not submitting together...