### PR TITLE
Fix osx build (again...)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
   - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 
 go_import_path: go.bug.st/serial.v1
 

--- a/enumerator/usb_darwin.go
+++ b/enumerator/usb_darwin.go
@@ -112,7 +112,7 @@ func serviceMatching(serviceType string) C.CFMutableDictionaryRef {
 // getMatchingServices look up registered IOService objects that match a matching dictionary.
 func getMatchingServices(matcher C.CFMutableDictionaryRef) (C.io_iterator_t, error) {
 	var i C.io_iterator_t
-	err := C.IOServiceGetMatchingServices(C.kIOMasterPortDefault, matcher, &i)
+	err := C.IOServiceGetMatchingServices(C.kIOMasterPortDefault, C.CFDictionaryRef(matcher), &i)
 	if err != C.KERN_SUCCESS {
 		return 0, fmt.Errorf("IOServiceGetMatchingServices failed (code %d)", err)
 	}


### PR DESCRIPTION
go1.10.4 and go1.11 introduced a change in how `C.CFDictionaryRef` are mapped from C lang to go land.

https://github.com/arduino/arduino-cli/issues/13
