### PR TITLE
Fixing getPortList on windows without any ports

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -30,7 +30,10 @@ func nativeGetPortsList() ([]string, error) {
 	}
 
 	var h syscall.Handle
-	if syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, subKey, 0, syscall.KEY_READ, &h) != nil {
+	if err := syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, subKey, 0, syscall.KEY_READ, &h); err != nil {
+		if errno, isErrno := err.(syscall.Errno); isErrno && errno == syscall.ERROR_FILE_NOT_FOUND {
+			return []string{}, nil
+		}
 		return nil, &PortError{code: ErrorEnumeratingPorts}
 	}
 	defer syscall.RegCloseKey(h)


### PR DESCRIPTION
Hello,

Thank you for creating this awesome library! We have found a problem where on machine without serial ports the library returns error `ErrorEnumeratingPorts`. We found it in VirtualBox machine. Issue occurs because the registry key `HARDWARE\DEVICEMAP\SERIALCOMM\` does not even exist. It seems a valid case to us and we think it should return empty slice instead of an error.

Please feel free to comment if the code is not up to your standards we would fix it.

Thank you.