### PR TITLE
Added support for go mods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ go:
   - 1.10.x
   - 1.11.x
 
-go_import_path: go.bug.st/serial.v1
+go_import_path: go.bug.st/serial
 
 env:
   - TEST_OS=linux TEST_ARCH=386
@@ -58,8 +58,8 @@ before_install:
 script:
   - GOARM=5 GO386=387 GOOS=$TEST_OS GOARCH=$TEST_ARCH go get github.com/stretchr/testify/require
   - GOARM=5 GO386=387 GOOS=$TEST_OS GOARCH=$TEST_ARCH go get golang.org/x/sys/windows
-  - GOARM=5 GO386=387 GOOS=$TEST_OS GOARCH=$TEST_ARCH go build -v go.bug.st/serial.v1
-  - GOARM=5 GO386=387 GOOS=$TEST_OS GOARCH=$TEST_ARCH go test -c -v go.bug.st/serial.v1
+  - GOARM=5 GO386=387 GOOS=$TEST_OS GOARCH=$TEST_ARCH go build -v go.bug.st/serial
+  - GOARM=5 GO386=387 GOOS=$TEST_OS GOARCH=$TEST_ARCH go test -c -v go.bug.st/serial
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 [![Build Status](https://travis-ci.org/bugst/go-serial.svg?branch=v1)](https://travis-ci.org/bugst/go-serial)
 
-# go.bug.st/serial.v1
+# go.bug.st/serial
 
 A cross-platform serial library for go-lang.
 
 ## Documentation and examples
 
-See the godoc here: https://godoc.org/go.bug.st/serial.v1
+See the godoc here: https://godoc.org/go.bug.st/serial
 
 ## Development
 
-If you want to contribute to the development of this library, you must clone this git repository directly into your `src` folder under `src/go.bug.st/serial.v1` and checkout the branch `v1`.
+If you want to contribute to the development of this library, you must clone this git repository directly into your `src` folder under `src/go.bug.st/serial` and checkout the branch `v1`.
 
 ```
 cd $GOPATH
 mkdir -p src/go.bug.st/
-git clone https://github.com/bugst/go-serial.git -b v1 src/go.bug.st/serial.v1
-go test go.bug.st/serial.v1
+git clone https://github.com/bugst/go-serial.git -b v1 src/go.bug.st/serial
+go test go.bug.st/serial
 ```
 
 ## What's new in v1
@@ -32,4 +32,3 @@ https://github.com/bugst/go-serial/pull/5/files
 The software is release under a BSD 3-clause license
 
 https://github.com/bugst/go-serial/blob/v1/LICENSE
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/bugst/go-serial.svg?branch=v1)](https://travis-ci.org/bugst/go-serial)
+[![Build Status](https://travis-ci.org/bugst/go-serial.svg?branch=master)](https://travis-ci.org/bugst/go-serial)
 
 # go.bug.st/serial
 
@@ -8,24 +8,11 @@ A cross-platform serial library for go-lang.
 
 See the godoc here: https://godoc.org/go.bug.st/serial
 
-## Development
+## go.mod transition
 
-If you want to contribute to the development of this library, you must clone this git repository directly into your `src` folder under `src/go.bug.st/serial` and checkout the branch `v1`.
+This library now support `go.mod` with the import `go.bug.st/serial`.
 
-```
-cd $GOPATH
-mkdir -p src/go.bug.st/
-git clone https://github.com/bugst/go-serial.git -b v1 src/go.bug.st/serial
-go test go.bug.st/serial
-```
-
-## What's new in v1
-
-There are some API improvements, in particular object naming is now more idiomatic, class names are less redundant (for example `serial.SerialPort` is now called `serial.Port`), some internal class fields, constants or enumerations are now private and some methods have been moved into the proper interface.
-
-If you come from the version v0 and want to see the full list of API changes, please check this pull request:
-
-https://github.com/bugst/go-serial/pull/5/files
+If you came from the pre-`go.mod` era please update your import paths from `go.bug.st/serial.v1` to `go.bug.st/serial` to receive new updates. Anyway, the latest "`v1`" release should still be avaiable using the old import.
 
 ## License
 

--- a/doc.go
+++ b/doc.go
@@ -7,10 +7,10 @@
 /*
 Package serial is a cross-platform serial library for the go language.
 
-The canonical import for this library is go.bug.st/serial.v1 so the import line
+The canonical import for this library is go.bug.st/serial so the import line
 is the following:
 
-	import "go.bug.st/serial.v1"
+	import "go.bug.st/serial"
 
 It is possible to get the list of available serial ports with the
 GetPortsList function:
@@ -84,7 +84,7 @@ cable or a microcontroller development board) is possible to retrieve
 the USB metadata, like VID/PID or USB Serial Number, with the
 GetDetailedPortsList function in the enumerator package:
 
-	import "go.bug.st/serial.v1/enumerator"
+	import "go.bug.st/serial/enumerator"
 
 	ports, err := enumerator.GetDetailedPortsList()
 	if err != nil {
@@ -110,4 +110,4 @@ Unfortunately the USB enumeration package for darwin (MacOSX) requires cgo
 to access the IOKit framework. This means that if you need USB enumeration
 on darwin you're forced to use cgo.
 */
-package serial // import "go.bug.st/serial.v1"
+package serial

--- a/enumerator/doc.go
+++ b/enumerator/doc.go
@@ -18,4 +18,4 @@ required in order to access the IOKit Framework. This means that the library
 cannot be easily cross compiled for GOOS=darwing targets.
 
 */
-package enumerator // import "go.bug.st/serial.v1/enumerator"
+package enumerator

--- a/enumerator/enumerator.go
+++ b/enumerator/enumerator.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package enumerator // import "go.bug.st/serial.v1/enumerator"
+package enumerator
 
 //go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -output syscall_windows.go usb_windows.go
 

--- a/enumerator/example_getdetailedportlist_test.go
+++ b/enumerator/example_getdetailedportlist_test.go
@@ -8,7 +8,7 @@ package enumerator_test
 
 import "fmt"
 import "log"
-import "go.bug.st/serial.v1/enumerator"
+import "go.bug.st/serial/enumerator"
 
 func ExampleGetDetailedPortsList() {
 	ports, err := enumerator.GetDetailedPortsList()

--- a/enumerator/usb_darwin.go
+++ b/enumerator/usb_darwin.go
@@ -6,7 +6,7 @@
 
 // +build go1.10,darwin
 
-package enumerator // import "go.bug.st/serial.v1/enumerator"
+package enumerator
 
 // #cgo LDFLAGS: -framework CoreFoundation -framework IOKit
 // #include <IOKit/IOKitLib.h>

--- a/enumerator/usb_darwin_go1.9.go
+++ b/enumerator/usb_darwin_go1.9.go
@@ -10,7 +10,7 @@
 // and is no more maintained or bugfixed, please update your go version
 // to at least 1.10 to get the latest updates.
 
-package enumerator // import "go.bug.st/serial.v1/enumerator"
+package enumerator
 
 // #cgo LDFLAGS: -framework CoreFoundation -framework IOKit
 // #include <IOKit/IOKitLib.h>

--- a/enumerator/usb_freebsd.go
+++ b/enumerator/usb_freebsd.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package enumerator // import "go.bug.st/serial.v1/enumerator"
+package enumerator
 
 func nativeGetDetailedPortsList() ([]*PortDetails, error) {
 	// TODO

--- a/enumerator/usb_linux.go
+++ b/enumerator/usb_linux.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package enumerator // import "go.bug.st/serial.v1/enumerator"
+package enumerator
 
 import (
 	"bufio"
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.bug.st/serial.v1"
+	"go.bug.st/serial"
 )
 
 func nativeGetDetailedPortsList() ([]*PortDetails, error) {

--- a/enumerator/usb_windows.go
+++ b/enumerator/usb_windows.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package enumerator // import "go.bug.st/serial.v1/enumerator"
+package enumerator
 
 import (
 	"fmt"

--- a/enumerator/usb_windows_test.go
+++ b/enumerator/usb_windows_test.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package enumerator // import "go.bug.st/serial.v1/enumerator"
+package enumerator
 
 import (
 	"testing"

--- a/example_getportlist_test.go
+++ b/example_getportlist_test.go
@@ -8,7 +8,7 @@ package serial_test
 
 import "fmt"
 import "log"
-import "go.bug.st/serial.v1"
+import "go.bug.st/serial"
 
 func ExampleGetPortsList() {
 	ports, err := serial.GetPortsList()

--- a/example_modem_bits_test.go
+++ b/example_modem_bits_test.go
@@ -7,7 +7,7 @@
 package serial_test
 
 import "log"
-import "go.bug.st/serial.v1"
+import "go.bug.st/serial"
 import "fmt"
 import "time"
 

--- a/example_serialport_test.go
+++ b/example_serialport_test.go
@@ -8,7 +8,7 @@ package serial_test
 
 import "fmt"
 import "log"
-import "go.bug.st/serial.v1"
+import "go.bug.st/serial"
 
 func ExampleSerialPort_SetMode() {
 	port, err := serial.Open("/dev/ttyACM0", &serial.Mode{})

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ package serial_test
 
 import "fmt"
 import "log"
-import "go.bug.st/serial.v1"
+import "go.bug.st/serial"
 
 // This example prints the list of serial ports and use the first one
 // to send a string "10,20,30" and prints the response on the screen.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module go.bug.st/serial
+
+go 1.13
+
+require (
+	github.com/creack/goselect v0.1.1
+	github.com/stretchr/testify v1.4.0
+	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/creack/goselect v0.1.1 h1:tiSSgKE1eJtxs1h/VgGQWuXUP0YS4CDIFMp6vaI1ls0=
+github.com/creack/goselect v0.1.1/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9 h1:ZBzSG/7F4eNKz2L3GE9o300RX0Az1Bw5HF7PDraD+qU=
+golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/portlist/portlist.go
+++ b/portlist/portlist.go
@@ -17,7 +17,7 @@ package main
 
 import "fmt"
 import "log"
-import "go.bug.st/serial.v1/enumerator"
+import "go.bug.st/serial/enumerator"
 
 func main() {
 	ports, err := enumerator.GetDetailedPortsList()

--- a/serial.go
+++ b/serial.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 //go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -output zsyscall_windows.go syscall_windows.go
 

--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/serial_darwin_386.go
+++ b/serial_darwin_386.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/serial_darwin_amd64.go
+++ b/serial_darwin_amd64.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/serial_freebsd.go
+++ b/serial_freebsd.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/serial_openbsd.go
+++ b/serial_openbsd.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -6,7 +6,7 @@
 
 // +build linux darwin freebsd openbsd
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import (
 	"io/ioutil"
@@ -16,8 +16,7 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/unix"
-
-	"go.bug.st/serial.v1/unixutils"
+	"go.bug.st/serial/unixutils"
 )
 
 type unixPort struct {

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 /*
 

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -4,6 +4,6 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 //sys ioctl(fd int, req uint64, data uintptr) (err error)

--- a/syscall_freebsd.go
+++ b/syscall_freebsd.go
@@ -4,6 +4,6 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 //sys ioctl(fd int, req uint64, data uintptr) (err error)

--- a/syscall_linux.go
+++ b/syscall_linux.go
@@ -4,6 +4,6 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 //sys ioctl(fd int, req uint64, data uintptr) (err error)

--- a/syscall_openbsd.go
+++ b/syscall_openbsd.go
@@ -4,6 +4,6 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 //sys ioctl(fd int, req uint64, data uintptr) (err error)

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 //sys regEnumValue(key syscall.Handle, index uint32, name *uint16, nameLen *uint32, reserved *uint32, class *uint16, value *uint16, valueLen *uint32) (regerrno error) = advapi32.RegEnumValueW
 

--- a/unixutils/pipe.go
+++ b/unixutils/pipe.go
@@ -6,7 +6,7 @@
 
 // +build linux darwin freebsd openbsd
 
-package unixutils // import "go.bug.st/serial.v1/unixutils"
+package unixutils
 
 import "syscall"
 import "fmt"

--- a/unixutils/select.go
+++ b/unixutils/select.go
@@ -6,7 +6,7 @@
 
 // +build linux darwin freebsd openbsd
 
-package unixutils // "go.bug.st/serial.v1/unixutils"
+package unixutils
 
 import (
 	"time"

--- a/zsyscall_darwin.go
+++ b/zsyscall_darwin.go
@@ -8,7 +8,7 @@
 //   mksyscall.pl serial_darwin.go
 // The generated stub is modified to make it compile under the "serial" package
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/zsyscall_freebsd.go
+++ b/zsyscall_freebsd.go
@@ -8,7 +8,7 @@
 //   mksyscall.pl serial_freebsd.go
 // The generated stub is modified to make it compile under the "serial" package
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/zsyscall_linux.go
+++ b/zsyscall_linux.go
@@ -8,7 +8,7 @@
 //   mksyscall.pl serial_linux.go
 // The generated stub is modified to make it compile under the "serial" package
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "golang.org/x/sys/unix"
 

--- a/zsyscall_openbsd.go
+++ b/zsyscall_openbsd.go
@@ -8,7 +8,7 @@
 //   mksyscall.pl serial_openbsd.go
 // The generated stub is modified to make it compile under the "serial" package
 
-package serial // import "go.bug.st/serial.v1"
+package serial
 
 import "syscall"
 


### PR DESCRIPTION
The import will change to `go.bug.st/serial`, the old one (`go.bug.st/serial.v1`) will continue to work but will not receive further updates.

Fix #49