### PR TITLE
Update example_test.go

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -54,7 +54,7 @@ func Example_sendAndReceive() {
 		n, err := port.Read(buff)
 		if err != nil {
 			log.Fatal(err)
-			break
+		
 		}
 		if n == 0 {
 			fmt.Println("\nEOF")


### PR DESCRIPTION
the break after log.Fatal(err) on line 57 is unnecessary as the program exitis anyways when log.Fatal is called
