### PR TITLE
update go generate

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -6,7 +6,7 @@
 
 package serial
 
-//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -output zsyscall_windows.go syscall_windows.go
+//go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go syscall_windows.go
 
 // Port is the interface for a serial Port
 type Port interface {


### PR DESCRIPTION
Replace old mkwinsyscall call by the new version which is recommended
by Go since version 1.13.3.

Based on https://github.com/golang/go/blob/go1.13.3/src/syscall/mksyscall_windows.go