### PR TITLE
add support for drain

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -26,6 +26,9 @@ type Port interface {
 	// Returns the number of bytes written.
 	Write(p []byte) (n int, err error)
 
+	// Wait until all data in the buffer are sent
+	Drain() error
+
 	// ResetInputBuffer Purges port read buffer
 	ResetInputBuffer() error
 

--- a/serial_bsd.go
+++ b/serial_bsd.go
@@ -1,0 +1,10 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package serial
+
+import "golang.org/x/sys/unix"
+
+func (port *unixPort) Drain() error {
+	return unix.IoctlSetInt(port.handle, unix.TIOCDRAIN, 0)
+}

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -85,3 +85,13 @@ func setTermSettingsBaudrate(speed int, settings *unix.Termios) (error, bool) {
 	settings.Ospeed = toTermiosSpeedType(baudrate)
 	return nil, false
 }
+
+func (port *unixPort) Drain() error {
+	// simulate drain with change settings with TCSETSW
+	settings, err := port.getTermSettings()
+	if err != nil {
+		return err
+	}
+
+	return unix.IoctlSetTermios(port.handle, unix.TCSETSW, settings)
+}

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -119,6 +119,10 @@ func (port *windowsPort) Write(p []byte) (int, error) {
 	return int(writed), err
 }
 
+func (port *windowsPort) Drain() (err error) {
+	return syscall.FlushFileBuffers(port.handle)
+}
+
 const (
 	purgeRxAbort uint32 = 0x0002
 	purgeRxClear        = 0x0008


### PR DESCRIPTION
Tested on Mac OS, Linux and Windows with UART emulated on USB.

I wrote general BSD code, because it should work, but I am not able to test it.

On Mac OS I am quite sure that drain behaves as needed.
For Windows it seems that drain is actually part of `Write`, because `Write` was slow and `Drain` was fast. But I have not found any mention in Win32 docs about buffering and asynchronous write, so I kept it.
For Linux `Drain` is also taking more time than writing.