### PR TITLE
Update zsyscall_darwin.go

### DIFF
--- a/zsyscall_darwin.go
+++ b/zsyscall_darwin.go
@@ -13,8 +13,8 @@ package serial
 import "golang.org/x/sys/unix"
 
 func ioctl(fd int, req uint64, data uintptr) (err error) {
-	_, _, e1 := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(data))
-	if e1 != 0 {
+	_, e1 := unix.IoctlGetTermios(fd, req)
+	if e1 != nil {
 		err = e1
 	}
 	return


### PR DESCRIPTION
Fix unix.SYS_IOCTL missing on recent Darwin