### PR TITLE
add support for darwin arm64

### DIFF
--- a/serial_darwin_64.go
+++ b/serial_darwin_64.go
@@ -1,3 +1,6 @@
+// +build darwin
+// +build amd64 arm64
+
 //
 // Copyright 2014-2020 Cristian Maglie. All rights reserved.
 // Use of this source code is governed by a BSD-style


### PR DESCRIPTION
Support arm64 which is used by the new lineup of computers
from apple.

Fixes #97 