### PR TITLE
Added support for macosx 10.11+

### DIFF
--- a/enumerator/usb_darwin.go
+++ b/enumerator/usb_darwin.go
@@ -47,9 +47,13 @@ func extractPortInfo(service C.io_registry_entry_t) (*PortDetails, error) {
 	port.Name = name
 	port.IsUSB = false
 
+	validUSBDeviceClass := map[string]bool{
+		"IOUSBDevice":     true,
+		"IOUSBHostDevice": true,
+	}
 	usbDevice := service
 	var searchErr error
-	for usbDevice.GetClass() != "IOUSBDevice" {
+	for !validUSBDeviceClass[usbDevice.GetClass()] {
 		if usbDevice, searchErr = usbDevice.GetParent("IOService"); searchErr != nil {
 			break
 		}


### PR DESCRIPTION
Seems like, starting from 10.11, `IOUSBDevice` has been renamed to `IOUSBHostDevice`.