### PR TITLE
Timeout : return an error compatible with os.IsTimeout()

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,9 @@ package serial_test
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
+	"time"
 
 	"go.bug.st/serial"
 )
@@ -53,11 +55,20 @@ func Example_sendAndReceive() {
 
 	// Read and print the response
 
+	if err := port.SetReadTimeout(1 * time.Minute); err != nil {
+		fmt.Printf("failed to set read timeout: %v\n", err)
+	}
+
 	buff := make([]byte, 100)
 	for {
 		// Reads up to 100 bytes
 		n, err := port.Read(buff)
 		if err != nil {
+			if os.IsTimeout(err) {
+				fmt.Println("timeout")
+				// TODO do something on read timeout
+				continue
+			}
 			log.Fatal(err)
 		}
 		if n == 0 {

--- a/serial.go
+++ b/serial.go
@@ -142,6 +142,8 @@ const (
 	PortClosed
 	// FunctionNotImplemented the requested function is not implemented
 	FunctionNotImplemented
+	// Timeout when an operation has timed out
+	Timeout
 )
 
 // EncodedErrorString returns a string explaining the error code
@@ -187,4 +189,9 @@ func (e PortError) Error() string {
 // Code returns an identifier for the kind of error occurred
 func (e PortError) Code() PortErrorCode {
 	return e.code
+}
+
+// Timeout returns true if is is a timeout (usable with os.IsTimeout)
+func (e PortError) Timeout() bool {
+	return e.code == Timeout
 }

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -86,7 +86,7 @@ func (port *unixPort) Read(p []byte) (int, error) {
 		}
 		if !res.IsReadable(port.handle) {
 			// Timeout happened
-			return 0, nil
+			return 0, &PortError{code: Timeout}
 		}
 		n, err := unix.Read(port.handle, p)
 		if err == unix.EINTR {

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -72,7 +72,7 @@ func (port *unixPort) Read(p []byte) (int, error) {
 	for {
 		timeout := time.Duration(-1)
 		if port.readTimeout != NoTimeout {
-			timeout = deadline.Sub(time.Now())
+			timeout = time.Until(deadline)
 		}
 		res, err := unixutils.Select(fds, nil, fds, timeout)
 		if err == unix.EINTR {

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -110,8 +110,8 @@ func (port *windowsPort) Read(p []byte) (int, error) {
 		if port.readTimeoutCycles != -1 {
 			cycles++
 			if cycles == port.readTimeoutCycles {
-				// Timeout
-				return 0, nil
+				// Timeout happened
+				return 0, &PortError{code: Timeout}
 			}
 		}
 


### PR DESCRIPTION
Like `*net.Conn.Read()` or `*os.File.Read()` when a timeout occurs, return an error that can be checked with `os.IsTimeout()`