### PR TITLE
Add Read cancellation

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -6,7 +6,10 @@
 
 package serial
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 //go:generate go run golang.org/x/sys/windows/mkwinsyscall -output zsyscall_windows.go syscall_windows.go
 
@@ -21,6 +24,13 @@ type Port interface {
 	// The Read function blocks until (at least) one byte is received from
 	// the serial port or an error occurs.
 	Read(p []byte) (n int, err error)
+
+	// Stores data received from the serial port into the provided byte array
+	// buffer. The function returns the number of bytes read.
+	//
+	// The Read function blocks until (at least) one byte is received from
+	// the serial port, an error occurs, or ctx is canceled.
+	ReadContext(ctx context.Context, p []byte) (n int, err error)
 
 	// Send the content of the data byte array to the serial port.
 	// Returns the number of bytes written.
@@ -142,6 +152,8 @@ const (
 	PortClosed
 	// FunctionNotImplemented the requested function is not implemented
 	FunctionNotImplemented
+	// ReadCanceled the read was canceled
+	ReadCanceled
 )
 
 // EncodedErrorString returns a string explaining the error code
@@ -171,6 +183,8 @@ func (e PortError) EncodedErrorString() string {
 		return "Port has been closed"
 	case FunctionNotImplemented:
 		return "Function not implemented"
+	case ReadCanceled:
+		return "Read was canceled"
 	default:
 		return "Other error"
 	}

--- a/serial_windows_test.go
+++ b/serial_windows_test.go
@@ -1,0 +1,115 @@
+package serial
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func openTestPort(t *testing.T) (Port, error) {
+	ports, err := GetPortsList()
+	if err != nil || len(ports) == 0 {
+		t.SkipNow()
+	}
+
+	mode := Mode{
+		BaudRate: 115200,
+		DataBits: 8,
+		Parity:   NoParity,
+		StopBits: OneStopBit,
+	}
+	return Open(ports[0], &mode)
+}
+
+func TestOpenClose(t *testing.T) {
+	// prevent port from being busy in other tests
+	defer time.Sleep(time.Millisecond)
+
+	port, err := openTestPort(t)
+	require.NoError(t, err)
+	port.Close()
+}
+
+func TestOpenReadClosed(t *testing.T) {
+	// prevent port from being busy in other tests
+	defer time.Sleep(time.Millisecond)
+
+	port, err := openTestPort(t)
+	require.NoError(t, err)
+	defer port.Close()
+
+	done := make(chan struct{})
+	var readErr error
+	go func() {
+		buf := make([]byte, 100)
+		_, readErr = port.ReadContext(context.Background(), buf)
+		close(done)
+	}()
+
+	time.Sleep(time.Millisecond)
+	select {
+	case <-done:
+		require.NoError(t, readErr)
+		require.Fail(t, "expected reading to be in-progress")
+	default:
+	}
+
+	port.Close()
+
+	time.Sleep(time.Millisecond)
+	select {
+	case <-done:
+	default:
+		require.Fail(t, "expected reading to be done")
+	}
+
+	var portErr *PortError
+	if !errors.As(readErr, &portErr) {
+		require.Fail(t, "expected read error to be a port error")
+	}
+	require.Equal(t, portErr.Code(), PortClosed)
+}
+
+func TestOpenReadCanceled(t *testing.T) {
+	// prevent port from being busy in other tests
+	defer time.Sleep(time.Millisecond)
+
+	port, err := openTestPort(t)
+	require.NoError(t, err)
+	defer port.Close()
+
+	readCtx, readCancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var readErr error
+	go func() {
+		buf := make([]byte, 100)
+		_, readErr = port.ReadContext(readCtx, buf)
+		close(done)
+	}()
+
+	time.Sleep(time.Millisecond)
+	select {
+	case <-done:
+		require.NoError(t, readErr)
+		require.Fail(t, "expected reading to be in-progress")
+	default:
+	}
+
+	readCancel()
+
+	time.Sleep(time.Millisecond)
+	select {
+	case <-done:
+	default:
+		require.Fail(t, "expected reading to be done")
+	}
+
+	var portErr *PortError
+	if !errors.As(readErr, &portErr) {
+		require.Fail(t, "expected read error to be a port error")
+	}
+	require.Equal(t, portErr.Code(), ReadCanceled)
+}


### PR DESCRIPTION
Fixes #105
Related to #117

In this solution, I gave serial.Serial a new function called ReadContext, which is identical to Read, except it also takes in a context.Context as its first parameter.

I understand that there may be some concern over the API, given that Go developers as a whole have not decided on how to resolve the problem of cancellation for abstract file systems, but it seems OK to add this feature, because the interface is defined in this library and is not a generalized interface that is a part of the standard library. I am happy to talk through any concerns.

I tested this on both Linux and Windows.
It probably also works for other Unix platforms, since their implementation is the same as Linux.

I cleaned up the Linux tests, since they weren't very careful.
Additionally, I added Windows tests, which were a bit trickier. I didn't see an obvious way to create a dummy serial port, so the tests will run using the first serial port on the system, otherwise skipping the tests.