### PR TITLE
Report Interface Number 

### DIFF
--- a/enumerator/enumerator.go
+++ b/enumerator/enumerator.go
@@ -15,6 +15,7 @@ type PortDetails struct {
 	IsUSB        bool
 	VID          string
 	PID          string
+        MI           string
 	SerialNumber string
 
 	// Manufacturer string

--- a/enumerator/usb_linux.go
+++ b/enumerator/usb_linux.go
@@ -72,6 +72,10 @@ func parseUSBSysFS(usbDevicePath string, details *PortDetails) error {
 	if err != nil {
 		return err
 	}
+	mi, err := readLine(filepath.Join(usbDevicePath, "bInterfaceNumber"))
+	if err != nil {
+		return err
+	}
 	serial, err := readLine(filepath.Join(usbDevicePath, "serial"))
 	if err != nil {
 		return err
@@ -88,6 +92,7 @@ func parseUSBSysFS(usbDevicePath string, details *PortDetails) error {
 	details.IsUSB = true
 	details.VID = vid
 	details.PID = pid
+	details.MI = mi
 	details.SerialNumber = serial
 	//details.Manufacturer = manufacturer
 	//details.Product = product

--- a/enumerator/usb_windows.go
+++ b/enumerator/usb_windows.go
@@ -18,32 +18,34 @@ import (
 func parseDeviceID(deviceID string, details *PortDetails) {
 	// Windows stock USB-CDC driver
 	if len(deviceID) >= 3 && deviceID[:3] == "USB" {
-		re := regexp.MustCompile("VID_(....)&PID_(....)(\\\\(\\w+)$)?").FindAllStringSubmatch(deviceID, -1)
-		if re == nil || len(re[0]) < 2 {
+		re := regexp.MustCompile("VID_(....)&PID_(....)&MI_(..)(\\\\(\\w+)$)?").FindAllStringSubmatch(deviceID, -1)
+		if re == nil || len(re[0]) < 3 {
 			// Silently ignore unparsable strings
 			return
 		}
 		details.IsUSB = true
 		details.VID = re[0][1]
 		details.PID = re[0][2]
-		if len(re[0]) >= 4 {
-			details.SerialNumber = re[0][4]
+		details.MI = re[0][3]
+		if len(re[0]) >= 5 {
+			details.SerialNumber = re[0][5]
 		}
 		return
 	}
 
 	// FTDI driver
 	if len(deviceID) >= 7 && deviceID[:7] == "FTDIBUS" {
-		re := regexp.MustCompile("VID_(....)\\+PID_(....)(\\+(\\w+))?").FindAllStringSubmatch(deviceID, -1)
-		if re == nil || len(re[0]) < 2 {
+		re := regexp.MustCompile("VID_(....)\\+PID_(....)+MI_(..)(\\+(\\w+))?").FindAllStringSubmatch(deviceID, -1)
+		if re == nil || len(re[0]) < 3 {
 			// Silently ignore unparsable strings
 			return
 		}
 		details.IsUSB = true
 		details.VID = re[0][1]
 		details.PID = re[0][2]
-		if len(re[0]) >= 4 {
-			details.SerialNumber = re[0][4]
+		details.MI = re[0][3]
+		if len(re[0]) >= 5 {
+			details.SerialNumber = re[0][5]
 		}
 		return
 	}


### PR DESCRIPTION
Many USB devices are composite devices that contain multiple interfaces. If such a device has two or more serial ports (comm ports) then they have the same VID, PID and Serial Number. Because of this, it is currently impossible to distinguish between multiple ports on the same USB composite device. It would be nice to be able to differentiate such devices at the USB level. This patch has the device info return the interface number (MI) in addition to the USB VID and PID. 

Tested and works on Window and Linux. I think a very similar change could be done to OSX for this to work on a MAC, but I do not have a MAC to test on.