### PR TITLE
Skip enumerating ports that are not accessible for any reason

### DIFF
--- a/serial_unix.go
+++ b/serial_unix.go
@@ -286,10 +286,7 @@ func nativeGetPortsList() ([]string, error) {
 		if strings.HasPrefix(f.Name(), "ttyS") {
 			port, err := nativeOpen(portName, &Mode{})
 			if err != nil {
-				serr, ok := err.(*PortError)
-				if ok && serr.Code() == InvalidSerialPort {
-					continue
-				}
+				continue
 			} else {
 				port.Close()
 			}


### PR DESCRIPTION
Otherwise, ports like `/dev/ttyS0` may be listed in case of "access denied" errors.