### PR TITLE
Fix potential small timeout bug on unix implementation

### DIFF
--- a/serial_unix.go
+++ b/serial_unix.go
@@ -72,7 +72,11 @@ func (port *unixPort) Read(p []byte) (int, error) {
 	for {
 		timeout := time.Duration(-1)
 		if port.readTimeout != NoTimeout {
-			timeout = deadline.Sub(time.Now())
+			timeout = time.Until(deadline)
+			if timeout < 0 {
+				// a negative timeout means "no-timeout" in Select(...)
+				timeout = 0
+			}
 		}
 		res, err := unixutils.Select(fds, nil, fds, timeout)
 		if err == unix.EINTR {


### PR DESCRIPTION
A very small port.readTimeout may lead to a negative timeout if the elapsed time between:

    deadline = time.Now().Add(port.readTimeout)

and

    timeout = time.Until(deadline)

is longer than port.readTimeout.

Fix #134