### PR TITLE
Added support for sending breaks

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -48,6 +48,9 @@ type Port interface {
 
 	// Close the serial port
 	Close() error
+
+	// Break sends a break for a determined time
+	Break(time.Duration) error
 }
 
 // NoTimeout should be used as a parameter to SetReadTimeout to disable timeout.

--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -14,6 +14,8 @@ const regexFilter = "^(cu|tty)\\..*"
 const ioctlTcgetattr = unix.TIOCGETA
 const ioctlTcsetattr = unix.TIOCSETA
 const ioctlTcflsh = unix.TIOCFLUSH
+const ioctlTioccbrk = unix.TIOCCBRK
+const ioctlTiocsbrk = unix.TIOCSBRK
 
 func setTermSettingsBaudrate(speed int, settings *unix.Termios) (error, bool) {
 	baudrate, ok := baudrateMap[speed]

--- a/serial_freebsd.go
+++ b/serial_freebsd.go
@@ -56,6 +56,8 @@ const tcCRTSCTS uint32 = tcCCTS_OFLOW
 const ioctlTcgetattr = unix.TIOCGETA
 const ioctlTcsetattr = unix.TIOCSETA
 const ioctlTcflsh = unix.TIOCFLUSH
+const ioctlTioccbrk = unix.TIOCCBRK
+const ioctlTiocsbrk = unix.TIOCSBRK
 
 func toTermiosSpeedType(speed uint32) uint32 {
 	return speed

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -63,6 +63,8 @@ const tcCRTSCTS uint32 = unix.CRTSCTS
 const ioctlTcgetattr = unix.TCGETS
 const ioctlTcsetattr = unix.TCSETS
 const ioctlTcflsh = unix.TCFLSH
+const ioctlTioccbrk = unix.TIOCCBRK
+const ioctlTiocsbrk = unix.TIOCSBRK
 
 func toTermiosSpeedType(speed uint32) uint32 {
 	return speed

--- a/serial_openbsd.go
+++ b/serial_openbsd.go
@@ -56,6 +56,8 @@ const tcCRTSCTS uint32 = tcCCTS_OFLOW
 const ioctlTcgetattr = unix.TIOCGETA
 const ioctlTcsetattr = unix.TIOCSETA
 const ioctlTcflsh = unix.TIOCFLUSH
+const ioctlTioccbrk = unix.TIOCCBRK
+const ioctlTiocsbrk = unix.TIOCSBRK
 
 func toTermiosSpeedType(speed uint32) int32 {
 	return int32(speed)

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -121,6 +121,20 @@ func (port *unixPort) ResetInputBuffer() error {
 	return unix.IoctlSetInt(port.handle, ioctlTcflsh, unix.TCIFLUSH)
 }
 
+func (port *unixPort) Break(t time.Duration) error {
+	if err := unix.IoctlSetInt(port.handle, ioctlTiocsbrk, 0); err != nil {
+		return err
+	}
+
+	time.Sleep(t)
+
+	if err := unix.IoctlSetInt(port.handle, ioctlTioccbrk, 0); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (port *unixPort) ResetOutputBuffer() error {
 	return unix.IoctlSetInt(port.handle, ioctlTcflsh, unix.TCOFLUSH)
 }

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -407,6 +407,10 @@ func (port *windowsPort) SetReadTimeout(timeout time.Duration) error {
 	return nil
 }
 
+func (port *windowsPort) Break(d time.Duration) error {
+	return &PortError{code: FunctionNotImplemented}
+}
+
 func createOverlappedEvent() (*syscall.Overlapped, error) {
 	h, err := createEvent(nil, true, false, nil)
 	return &syscall.Overlapped{HEvent: h}, err


### PR DESCRIPTION
I added support for sending an arbitrary length break signal

Linux has a TCSBRKP ioctl which does it in a single ioctl but all the other unixes did not support it, so I used TIOCSBRK/TIOCCBRK instead

I've only tested it on Linux with a logic analyzer and its working fine.
Windows support has not been added 