### PR TITLE
Allow setting RTS and DTR on `Open`

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -64,6 +64,9 @@ type ModemStatusBits struct {
 
 // ModemOutputBits contains all the modem output bits for a serial port.
 // This is used in the Mode.InitialStatusBits struct to specify the initial status of the bits.
+// Note: Linux and MacOSX (and basically all unix-based systems) can not set the status bits
+// before opening the port, even if the initial state of the bit is set to false they will go
+// anyway to true for a few milliseconds, resulting in a small pulse.
 type ModemOutputBits struct {
 	RTS bool // ReadyToSend status
 	DTR bool // DataTerminalReady status

--- a/serial.go
+++ b/serial.go
@@ -53,13 +53,20 @@ type Port interface {
 // NoTimeout should be used as a parameter to SetReadTimeout to disable timeout.
 var NoTimeout time.Duration = -1
 
-// ModemStatusBits contains all the modem status bits for a serial port (CTS, DSR, etc...).
+// ModemStatusBits contains all the modem input status bits for a serial port (CTS, DSR, etc...).
 // It can be retrieved with the Port.GetModemStatusBits() method.
 type ModemStatusBits struct {
 	CTS bool // ClearToSend status
 	DSR bool // DataSetReady status
 	RI  bool // RingIndicator status
 	DCD bool // DataCarrierDetect status
+}
+
+// ModemOutputBits contains all the modem output bits for a serial port.
+// This is used in the Mode.InitialStatusBits struct to specify the initial status of the bits.
+type ModemOutputBits struct {
+	RTS bool // ReadyToSend status
+	DTR bool // DataTerminalReady status
 }
 
 // Open opens the serial port using the specified modes
@@ -74,12 +81,11 @@ func GetPortsList() ([]string, error) {
 
 // Mode describes a serial port configuration.
 type Mode struct {
-	BaudRate   int      // The serial port bitrate (aka Baudrate)
-	DataBits   int      // Size of the character (must be 5, 6, 7 or 8)
-	Parity     Parity   // Parity (see Parity type for more info)
-	StopBits   StopBits // Stop bits (see StopBits type for more info)
-	InitialRTS bool     // Initial state for RTS
-	InitialDTR bool     // Initial state for DTR
+	BaudRate          int              // The serial port bitrate (aka Baudrate)
+	DataBits          int              // Size of the character (must be 5, 6, 7 or 8)
+	Parity            Parity           // Parity (see Parity type for more info)
+	StopBits          StopBits         // Stop bits (see StopBits type for more info)
+	InitialStatusBits *ModemOutputBits // Initial output modem bits status (if nil defaults to DTR=true and RTS=true)
 }
 
 // Parity describes a serial port parity setting

--- a/serial.go
+++ b/serial.go
@@ -74,10 +74,12 @@ func GetPortsList() ([]string, error) {
 
 // Mode describes a serial port configuration.
 type Mode struct {
-	BaudRate int      // The serial port bitrate (aka Baudrate)
-	DataBits int      // Size of the character (must be 5, 6, 7 or 8)
-	Parity   Parity   // Parity (see Parity type for more info)
-	StopBits StopBits // Stop bits (see StopBits type for more info)
+	BaudRate   int      // The serial port bitrate (aka Baudrate)
+	DataBits   int      // Size of the character (must be 5, 6, 7 or 8)
+	Parity     Parity   // Parity (see Parity type for more info)
+	StopBits   StopBits // Stop bits (see StopBits type for more info)
+	InitialRTS bool     // Initial state for RTS
+	InitialDTR bool     // Initial state for DTR
 }
 
 // Parity describes a serial port parity setting

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -235,6 +235,9 @@ func nativeOpen(portName string, mode *Mode) (*unixPort, error) {
 	// Explicitly disable RTS/CTS flow control
 	setTermSettingsCtsRts(false, settings)
 
+	port.SetDTR(mode.InitialDTR)
+	port.SetRTS(mode.InitialRTS)
+
 	if port.setTermSettings(settings) != nil {
 		port.Close()
 		return nil, &PortError{code: InvalidSerialPort}

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -450,13 +450,18 @@ func nativeOpen(portName string, mode *Mode) (*windowsPort, error) {
 		port.Close()
 		return nil, &PortError{code: InvalidSerialPort}
 	}
-	params.Flags &= dcbRTSControlDisbaleMask
-	if mode.InitialRTS {
-		params.Flags |= dcbRTSControlEnable
-	}
 	params.Flags &= dcbDTRControlDisableMask
-	if mode.InitialDTR {
+	params.Flags &= dcbRTSControlDisbaleMask
+	if mode.InitialStatusBits == nil {
 		params.Flags |= dcbDTRControlEnable
+		params.Flags |= dcbRTSControlEnable
+	} else {
+		if mode.InitialStatusBits.DTR {
+			params.Flags |= dcbDTRControlEnable
+		}
+		if mode.InitialStatusBits.RTS {
+			params.Flags |= dcbRTSControlEnable
+		}
 	}
 	params.Flags &^= dcbOutXCTSFlow
 	params.Flags &^= dcbOutXDSRFlow

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -451,9 +451,13 @@ func nativeOpen(portName string, mode *Mode) (*windowsPort, error) {
 		return nil, &PortError{code: InvalidSerialPort}
 	}
 	params.Flags &= dcbRTSControlDisbaleMask
-	params.Flags |= dcbRTSControlEnable
+	if mode.InitialRTS {
+		params.Flags |= dcbRTSControlEnable
+	}
 	params.Flags &= dcbDTRControlDisableMask
-	params.Flags |= dcbDTRControlEnable
+	if mode.InitialDTR {
+		params.Flags |= dcbDTRControlEnable
+	}
 	params.Flags &^= dcbOutXCTSFlow
 	params.Flags &^= dcbOutXDSRFlow
 	params.Flags &^= dcbDSRSensitivity


### PR DESCRIPTION
Based on #47, the API is slightly different to allow `DTR` and `RTS` to default to `true` if not specified:
```
	port, err := serial.Open("/dev/ttyUSB0", &serial.Mode{BaudRate: 9600})
```

this is the full initialization:
```
	port, err := serial.Open("/dev/ttyUSB0", &serial.Mode{
		BaudRate: 9600,
		DataBits: 8,
		Parity:   serial.NoParity,
		StopBits: serial.OneStopBit,
		InitialStatusBits: &serial.ModemOutputBits{
			RTS: true,
			DTR: false,
		},
	})
```
