### PR TITLE
Remove unnecessary code, originally for checking for disconnects when using non-overlapped I/O

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -114,17 +114,6 @@ func (port *windowsPort) Read(p []byte) (int, error) {
 				return 0, nil
 			}
 		}
-
-		// At the moment it seems that the only reliable way to check if
-		// a serial port is alive in Windows is to check if the SetCommState
-		// function fails.
-
-		params := &dcb{}
-		getCommState(port.handle, params)
-		if err := setCommState(port.handle, params); err != nil {
-			port.Close()
-			return 0, err
-		}
 	}
 }
 


### PR DESCRIPTION
getOverlappedEvent() returns all required error codes.  Calling getCommState()/setCommState() every second in some applications contributes to other downstream issues.  

For examples: 
[https://github.com/bugst/go-serial/issues/60#issuecomment-625749122](https://github.com/bugst/go-serial/issues/60#issuecomment-625749122)
[https://github.com/bugst/go-serial/issues/60#issuecomment-625749122](https://github.com/arduino/arduino-ide/issues/375)