### PR TITLE
Remove unnecessary code, originally for checking for disconnects when using non-overlapped I/O

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -114,17 +114,6 @@ func (port *windowsPort) Read(p []byte) (int, error) {
 				return 0, nil
 			}
 		}
-
-		// At the moment it seems that the only reliable way to check if
-		// a serial port is alive in Windows is to check if the SetCommState
-		// function fails.
-
-		params := &dcb{}
-		getCommState(port.handle, params)
-		if err := setCommState(port.handle, params); err != nil {
-			port.Close()
-			return 0, err
-		}
 	}
 }
 


### PR DESCRIPTION
Build on top of #144 (thanks @palazzol).

I've taken the commit from #144 and removed also the timeout logic that is no more needed.
