### PR TITLE
windows: Avoid panic if USB Product name is empty

### DIFF
--- a/enumerator/usb_windows.go
+++ b/enumerator/usb_windows.go
@@ -347,10 +347,12 @@ func retrievePortDetailsFromDevInfo(device *deviceInfo, details *PortDetails) er
 		the result of spdrpFriendlyName is therefore unique and suitable as an alternative string to for a port choice */
 	n := uint32(0)
 	setupDiGetDeviceRegistryProperty(device.set, &device.data, spdrpFriendlyName /* spdrpDeviceDesc */, nil, nil, 0, &n)
-	buff := make([]uint16, n*2)
-	buffP := (*byte)(unsafe.Pointer(&buff[0]))
-	if setupDiGetDeviceRegistryProperty(device.set, &device.data, spdrpFriendlyName /* spdrpDeviceDesc */, nil, buffP, n, &n) {
-		details.Product = syscall.UTF16ToString(buff[:])
+	if n > 0 {
+		buff := make([]uint16, n*2)
+		buffP := (*byte)(unsafe.Pointer(&buff[0]))
+		if setupDiGetDeviceRegistryProperty(device.set, &device.data, spdrpFriendlyName /* spdrpDeviceDesc */, nil, buffP, n, &n) {
+			details.Product = syscall.UTF16ToString(buff[:])
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Should fix #138 