### PR TITLE
feat: add ttyHS support for linux

### DIFF
--- a/serial_linux.go
+++ b/serial_linux.go
@@ -9,7 +9,7 @@ package serial
 import "golang.org/x/sys/unix"
 
 const devFolder = "/dev"
-const regexFilter = "(ttyS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO|ttymxc)[0-9]{1,3}"
+const regexFilter = "(ttyS|ttyHS|ttyUSB|ttyACM|ttyAMA|rfcomm|ttyO|ttymxc)[0-9]{1,3}"
 
 // termios manipulation functions
 

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -313,8 +313,8 @@ func nativeGetPortsList() ([]string, error) {
 
 		portName := devFolder + "/" + f.Name()
 
-		// Check if serial port is real or is a placeholder serial port "ttySxx"
-		if strings.HasPrefix(f.Name(), "ttyS") {
+		// Check if serial port is real or is a placeholder serial port "ttySxx" or "ttyHSxx"
+		if strings.HasPrefix(f.Name(), "ttyS") || strings.HasPrefix(f.Name(), "ttyHS") {
 			port, err := nativeOpen(portName, &Mode{})
 			if err != nil {
 				continue


### PR DESCRIPTION
Add ttyHS support for linux.

Tested with `example_getportlist_test` on Linux ARM64, Linux AMD64 and Windows.

Linux can get ttyHSxxx and ttySxxx, Windows can get COMx.