### PR TITLE
Fix some rare MacOSX USB port enumerator failures

### DIFF
--- a/enumerator/usb_darwin.go
+++ b/enumerator/usb_darwin.go
@@ -97,8 +97,8 @@ func getAllServices(serviceType string) ([]io_object_t, error) {
 			services = append(services, service)
 			continue
 		}
-		// If iterator is still valid return the result
-		if i.IsValid() {
+		// If the list of services is empty or the iterator is still valid return the result
+		if len(services) == 0 || i.IsValid() {
 			return services, nil
 		}
 		// Otherwise empty the result and retry


### PR DESCRIPTION
We had reports of users always getting:

```
IOServiceGetMatchingServices failed, data changed while iterating
```

The issue seems related to the function getMatchingServices which returns an always-invalid iterator even if there are no actual services.

This is a workaround for this issue.