### PR TITLE
Make exclusive access optional

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -101,6 +101,7 @@ type Mode struct {
 	Parity            Parity           // Parity (see Parity type for more info)
 	StopBits          StopBits         // Stop bits (see StopBits type for more info)
 	InitialStatusBits *ModemOutputBits // Initial output modem bits status (if nil defaults to DTR=true and RTS=true)
+	AccessMode        AccessMode       // Access mode on unix systems (Default: Exclusive)
 }
 
 // Parity describes a serial port parity setting
@@ -129,6 +130,14 @@ const (
 	OnePointFiveStopBits
 	// TwoStopBits sets 2 stop bits
 	TwoStopBits
+)
+
+// AccessMode whether to access the port exclusively
+type AccessMode int
+
+const (
+	Exclusive = 0
+	Shared    = 1
 )
 
 // PortError is a platform independent error type for serial ports

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -275,7 +275,9 @@ func nativeOpen(portName string, mode *Mode) (*unixPort, error) {
 
 	unix.SetNonblock(h, false)
 
-	port.acquireExclusiveAccess()
+	if mode.AccessMode == Exclusive {
+		port.acquireExclusiveAccess()
+	}
 
 	// This pipe is used as a signal to cancel blocking Read
 	pipe := &unixutils.Pipe{}


### PR DESCRIPTION
I noticed that there is no option to disable the exclusive access on the port.
Please be lenient with me, this is my first time writing go code.