### PR TITLE
unix: nativeOpen: always close the port on errors

### DIFF
--- a/serial_unix.go
+++ b/serial_unix.go
@@ -249,6 +249,7 @@ func nativeOpen(portName string, mode *Mode) (*unixPort, error) {
 	if mode.InitialStatusBits != nil {
 		status, err := port.getModemBitsStatus()
 		if err != nil {
+			port.Close()
 			return nil, &PortError{code: InvalidSerialPort, causedBy: err}
 		}
 		if mode.InitialStatusBits.DTR {
@@ -262,6 +263,7 @@ func nativeOpen(portName string, mode *Mode) (*unixPort, error) {
 			status &^= unix.TIOCM_RTS
 		}
 		if err := port.setModemBitsStatus(status); err != nil {
+			port.Close()
 			return nil, &PortError{code: InvalidSerialPort, causedBy: err}
 		}
 	}


### PR DESCRIPTION
I noticed there were a few cases where `nativeOpen()` would return an error but wouldn't explicitly close the port, I've fixed those cases.