### PR TITLE
fix: add shims for GOARCH=wasm with GOOS=js and GOOS=wasip1

### DIFF
--- a/enumerator/usb_wasm.go
+++ b/enumerator/usb_wasm.go
@@ -1,0 +1,11 @@
+//
+// Copyright 2014-2024 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package enumerator
+
+func nativeGetDetailedPortsList() ([]*PortDetails, error) {
+	return nil, &PortEnumerationError{}
+}

--- a/enumerator_wasm.go
+++ b/enumerator_wasm.go
@@ -1,0 +1,15 @@
+//
+// Copyright 2014-2024 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package serial
+
+import (
+	"errors"
+)
+
+func nativeGetPortsList() ([]string, error) {
+	return nil, errors.New("nativeGetPortsList is not supported on wasm")
+}

--- a/serial_wasm.go
+++ b/serial_wasm.go
@@ -1,0 +1,15 @@
+//
+// Copyright 2014-2024 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package serial
+
+import (
+	"errors"
+)
+
+func nativeOpen(portName string, mode *Mode) (Port, error) {
+	return nil, errors.New("nativeOpen is not supported on wasm")
+}


### PR DESCRIPTION
Fixes build errors:

GOOS=js GOARCH=wasm go build
GOOS=wasip1 GOARCH=wasm go build