### PR TITLE
Add NetBSD support

### DIFF
--- a/enumerator/usb_netbsd.go
+++ b/enumerator/usb_netbsd.go
@@ -7,6 +7,8 @@
 package enumerator
 
 import (
+	"strings"
+
 	"go.bug.st/serial"
 )
 
@@ -19,7 +21,20 @@ func nativeGetDetailedPortsList() ([]*PortDetails, error) {
 
 	var res []*PortDetails
 	for _, port := range ports {
-		res = append(res, &PortDetails{Name: port})
+		details, err := nativeGetPortDetails(port)
+		if err != nil {
+			return nil, &PortEnumerationError{causedBy: err}
+		}
+		res = append(res, details)
 	}
 	return res, nil
+}
+
+func nativeGetPortDetails(portPath string) (*PortDetails, error) {
+	result := &PortDetails{Name: portPath}
+
+	if strings.Contains(result.Name, "U") {
+		result.IsUSB = true
+	}
+	return result, nil
 }

--- a/enumerator/usb_netbsd.go
+++ b/enumerator/usb_netbsd.go
@@ -1,0 +1,25 @@
+//
+// Copyright 2014-2023 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package enumerator
+
+import (
+	"go.bug.st/serial"
+)
+
+func nativeGetDetailedPortsList() ([]*PortDetails, error) {
+	// Retrieve the port list
+	ports, err := serial.GetPortsList()
+	if err != nil {
+		return nil, &PortEnumerationError{causedBy: err}
+	}
+
+	var res []*PortDetails
+	for _, port := range ports {
+		res = append(res, &PortDetails{Name: port})
+	}
+	return res, nil
+}

--- a/serial_netbsd.go
+++ b/serial_netbsd.go
@@ -48,10 +48,9 @@ var databitsMap = map[int]uint32{
 const tcCMSPAR uint32 = 0 // may be CMSPAR or PAREXT
 const tcIUCLC uint32 = 0
 
-const tcCCTS_OFLOW uint32 = 0x00010000
-const tcCRTS_IFLOW uint32 = 0x00020000
-
-const tcCRTSCTS uint32 = tcCCTS_OFLOW
+const tcCRTSCTS uint32 = 0x00010000
+const tcCCTS_OFLOW uint32 = tcCCTS_OFLOW
+const tcCRTS_IFLOW uint32 = tcCCTS_OFLOW
 
 const ioctlTcgetattr = unix.TIOCGETA
 const ioctlTcsetattr = unix.TIOCSETA
@@ -68,13 +67,6 @@ func setTermSettingsBaudrate(speed int, settings *unix.Termios) (error, bool) {
 	if !ok {
 		return nil, true
 	}
-	// XXX: Is Cflag really needed
-	// revert old baudrate
-	for _, rate := range baudrateMap {
-		settings.Cflag &^= rate
-	}
-	// set new baudrate
-	settings.Cflag |= baudrate
 
 	settings.Ispeed = toTermiosSpeedType(baudrate)
 	settings.Ospeed = toTermiosSpeedType(baudrate)

--- a/serial_netbsd.go
+++ b/serial_netbsd.go
@@ -1,0 +1,87 @@
+//
+// Copyright 2014-2023 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+package serial
+
+import "golang.org/x/sys/unix"
+
+const devFolder = "/dev"
+const regexFilter = "^(dty|tty)\\..*"
+
+// termios manipulation functions
+
+var baudrateMap = map[int]uint32{
+	0:      unix.B9600, // Default to 9600
+	50:     unix.B50,
+	75:     unix.B75,
+	110:    unix.B110,
+	134:    unix.B134,
+	150:    unix.B150,
+	200:    unix.B200,
+	300:    unix.B300,
+	600:    unix.B600,
+	1200:   unix.B1200,
+	1800:   unix.B1800,
+	2400:   unix.B2400,
+	4800:   unix.B4800,
+	9600:   unix.B9600,
+	19200:  unix.B19200,
+	38400:  unix.B38400,
+	57600:  unix.B57600,
+	115200: unix.B115200,
+	230400: unix.B230400,
+	460800: unix.B460800,
+	921600: unix.B921600,
+}
+
+var databitsMap = map[int]uint32{
+	0: unix.CS8, // Default to 8 bits
+	5: unix.CS5,
+	6: unix.CS6,
+	7: unix.CS7,
+	8: unix.CS8,
+}
+
+const tcCMSPAR uint32 = 0 // may be CMSPAR or PAREXT
+const tcIUCLC uint32 = 0
+
+const tcCCTS_OFLOW uint32 = 0x00010000
+const tcCRTS_IFLOW uint32 = 0x00020000
+
+const tcCRTSCTS uint32 = tcCCTS_OFLOW
+
+const ioctlTcgetattr = unix.TIOCGETA
+const ioctlTcsetattr = unix.TIOCSETA
+const ioctlTcflsh = unix.TIOCFLUSH
+const ioctlTioccbrk = unix.TIOCCBRK
+const ioctlTiocsbrk = unix.TIOCSBRK
+
+func toTermiosSpeedType(speed uint32) int32 {
+	return int32(speed)
+}
+
+func setTermSettingsBaudrate(speed int, settings *unix.Termios) (error, bool) {
+	baudrate, ok := baudrateMap[speed]
+	if !ok {
+		return nil, true
+	}
+	// XXX: Is Cflag really needed
+	// revert old baudrate
+	for _, rate := range baudrateMap {
+		settings.Cflag &^= rate
+	}
+	// set new baudrate
+	settings.Cflag |= baudrate
+
+	settings.Ispeed = toTermiosSpeedType(baudrate)
+	settings.Ospeed = toTermiosSpeedType(baudrate)
+	return nil, false
+}
+
+func (port *unixPort) setSpecialBaudrate(speed uint32) error {
+	// TODO: unimplemented
+	return &PortError{code: InvalidSpeed}
+}

--- a/serial_netbsd.go
+++ b/serial_netbsd.go
@@ -9,7 +9,7 @@ package serial
 import "golang.org/x/sys/unix"
 
 const devFolder = "/dev"
-const regexFilter = "^(dty|tty)\\..*"
+const regexFilter = "(dty|tty|dtyU|ttyU)[0-9]{1,2}"
 
 // termios manipulation functions
 

--- a/serial_netbsd.go
+++ b/serial_netbsd.go
@@ -49,8 +49,8 @@ const tcCMSPAR uint32 = 0 // may be CMSPAR or PAREXT
 const tcIUCLC uint32 = 0
 
 const tcCRTSCTS uint32 = 0x00010000
-const tcCCTS_OFLOW uint32 = tcCCTS_OFLOW
-const tcCRTS_IFLOW uint32 = tcCCTS_OFLOW
+const tcCCTS_OFLOW uint32 = tcCRTSCTS
+const tcCRTS_IFLOW uint32 = tcCRTSCTS
 
 const ioctlTcgetattr = unix.TIOCGETA
 const ioctlTcsetattr = unix.TIOCSETA

--- a/serial_resetbuf_linux_bsd.go
+++ b/serial_resetbuf_linux_bsd.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-//go:build linux || freebsd || openbsd
+//go:build linux || freebsd || netbsd || openbsd
 
 package serial
 

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-//go:build linux || darwin || freebsd || openbsd
+//go:build linux || darwin || freebsd || netbsd || openbsd
 
 package serial
 

--- a/unixutils/pipe.go
+++ b/unixutils/pipe.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-//go:build linux || darwin || freebsd || openbsd
+//go:build linux || darwin || freebsd || netbsd || openbsd
 
 package unixutils
 

--- a/unixutils/select.go
+++ b/unixutils/select.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 //
 
-//go:build linux || darwin || freebsd || openbsd
+//go:build linux || darwin || freebsd || netbsd || openbsd
 
 package unixutils
 


### PR DESCRIPTION
Test with arduino-cli 0.35.3:

picohive: {/home/rxg} uname -a
NetBSD picohive 9.3 NetBSD 9.3 (GENERIC) #0: Thu Aug  4 15:30:37 UTC 2022  mkrepro@mkrepro.NetBSD.org:/usr/src/sys/arch/amd64/compile/GENERIC amd64
picohive: {/home/rxg} arduino-cli board list
Port       Protocol Type              Board Name FQBN Core
/dev/dty00 serial   Serial Port       Unknown
/dev/dty01 serial   Serial Port       Unknown
/dev/dty02 serial   Serial Port       Unknown
/dev/dty03 serial   Serial Port       Unknown
/dev/dtyU0 serial   Serial Port (USB) Unknown
/dev/dtyU1 serial   Serial Port (USB) Unknown
/dev/dtyU2 serial   Serial Port (USB) Unknown
/dev/dtyU3 serial   Serial Port (USB) Unknown
/dev/dtyU4 serial   Serial Port (USB) Unknown
/dev/dtyU5 serial   Serial Port (USB) Unknown
/dev/dtyU6 serial   Serial Port (USB) Unknown
/dev/dtyU7 serial   Serial Port (USB) Unknown
/dev/tty00 serial   Serial Port       Unknown
/dev/tty01 serial   Serial Port       Unknown
/dev/tty02 serial   Serial Port       Unknown
/dev/tty03 serial   Serial Port       Unknown
/dev/ttyU0 serial   Serial Port (USB) Unknown
/dev/ttyU1 serial   Serial Port (USB) Unknown
/dev/ttyU2 serial   Serial Port (USB) Unknown
/dev/ttyU3 serial   Serial Port (USB) Unknown
/dev/ttyU4 serial   Serial Port (USB) Unknown
/dev/ttyU5 serial   Serial Port (USB) Unknown
/dev/ttyU6 serial   Serial Port (USB) Unknown
/dev/ttyU7 serial   Serial Port (USB) Unknown

picohive: {/home/rxg} arduino-cli monitor -p /dev/ttyU0 -c baudrate=115200
Monitor port settings:
baudrate=115200
Connected to /dev/ttyU0! Press CTRL-C to exit.
Bpm:0,SPO2:90.00
Bpm:0,SPO2:90.00
Bpm:0,SPO2:90.00
