### PR TITLE
Fix flags for FreeBSD/arm64

### DIFF
--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -22,6 +22,9 @@ const ioctlTcflsh = unix.TIOCFLUSH
 const ioctlTioccbrk = unix.TIOCCBRK
 const ioctlTiocsbrk = unix.TIOCSBRK
 
+const tcSetOflags uint64 = 0
+const tcClearOflags uint64 = 0
+
 func setTermSettingsBaudrate(speed int, settings *unix.Termios) (error, bool) {
 	baudrate, ok := baudrateMap[speed]
 	if !ok {

--- a/serial_freebsd.go
+++ b/serial_freebsd.go
@@ -58,8 +58,8 @@ const tcCRTS_IFLOW uint32 = 0x00020000
 
 const tcCRTSCTS uint32 = tcCCTS_OFLOW
 
-const tcSetOflags uint32 = 0
-const tcClearOflags uint32 = unix.OPOST
+const tcSetOflags uint32 = unix.OPOST
+const tcClearOflags uint32 = 0
 
 const ioctlTcgetattr = unix.TIOCGETA
 const ioctlTcsetattr = unix.TIOCSETA

--- a/serial_freebsd.go
+++ b/serial_freebsd.go
@@ -58,6 +58,9 @@ const tcCRTS_IFLOW uint32 = 0x00020000
 
 const tcCRTSCTS uint32 = tcCCTS_OFLOW
 
+const tcSetOflags uint32 = 0
+const tcClearOflags uint32 = unix.OPOST
+
 const ioctlTcgetattr = unix.TIOCGETA
 const ioctlTcsetattr = unix.TIOCSETA
 const ioctlTcflsh = unix.TIOCFLUSH
@@ -73,14 +76,6 @@ func setTermSettingsBaudrate(speed int, settings *unix.Termios) (error, bool) {
 	if !ok {
 		return nil, true
 	}
-	// XXX: Is Cflag really needed
-	// revert old baudrate
-	for _, rate := range baudrateMap {
-		settings.Cflag &^= rate
-	}
-	// set new baudrate
-	settings.Cflag |= baudrate
-
 	settings.Ispeed = toTermiosSpeedType(baudrate)
 	settings.Ospeed = toTermiosSpeedType(baudrate)
 	return nil, false

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -63,6 +63,9 @@ var databitsMap = map[int]uint32{
 const tcCMSPAR = unix.CMSPAR
 const tcIUCLC = unix.IUCLC
 
+const tcSetOflags uint32 = 0
+const tcClearOflags uint32 = 0
+
 const tcCRTSCTS uint32 = unix.CRTSCTS
 
 const ioctlTcgetattr = unix.TCGETS

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -434,6 +434,8 @@ func setRawMode(settings *unix.Termios) {
 	settings.Iflag &^= tcIUCLC
 
 	settings.Oflag &^= unix.OPOST
+	settings.Oflag &^= tcClearOflags // Needed to clear platform specific flags
+	settings.Oflag |= tcSetOflags    // Needed to set platform specific flags
 
 	// Block reads until at least one char is available (no timeout)
 	settings.Cc[unix.VMIN] = 1


### PR DESCRIPTION
Couldn't get this package to work with FreeBSD on arm64, and eventually figured out why.

- Setting the Control flags with the baud rate seems to break things, specifically the word size.  Removing that solved the issue.
- The post-processing output flag is needed.  Turning that flag off broke newline handling and control codes.  In order to turn that on only for FreeBSD, a constant was added with set and clear values that can then be added in each os-specific file.  I set the correct values for FreeBSD and then set zero values in the other UNIX os files.  Hoping this should keep it working everywhere else (since I also tested on linux/arm64 and darwin/arm64 and it worked fine there).

-Confirmed setting baud rate and parity work correctly with the changes on FreeBSD/arm64.