### PR TITLE
Go-format source code: fix warning

### DIFF
--- a/portlist/portlist.go
+++ b/portlist/portlist.go
@@ -12,7 +12,7 @@
 // Port: /dev/cu.usbmodemFD121
 //    USB ID     2341:8053
 //    USB serial FB7B6060504B5952302E314AFF08191A
-//
+
 package main
 
 import (


### PR DESCRIPTION
When [checking](https://goreportcard.com/report/go.bug.st/serial) the project with Go Report card service there is a warning that the code is not 100% formatted to Go standard. This PR fixes this issue.