### PR TITLE
Bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-go@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@5
         with:
-          go-version: "1.17"
+          go-version: "1.22"
       - name: Build native
         run: GOARCH=amd64 go build -v ./...
         shell: bash
@@ -51,10 +51,10 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-go@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.17"
+          go-version: "1.22"
       - name: Cross-build
         run: |
           set ${{ matrix.go-os-pairs }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@5
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.22"
       - name: Setup CGO Environment


### PR DESCRIPTION
This PR bumps GitHub workflow actions to latest versions, thus avoiding deprecation warnings, as e.g. seen [here](https://github.com/bugst/go-serial/actions/runs/8237610031).