### PR TITLE
Workflows: Use CGO_ENABLED=1 for MacOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,8 +19,17 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: "1.17"
-      - name: Build native
+      - name: Setup CGO Environment
+        run: |
+          if [ ${{ matrix.os }} == 'macOS-latest' ] ; then
+            echo "CGO_ENABLED=1" >> "$GITHUB_ENV"
+          fi
+        shell: bash
+      - name: Build AMD64
         run: GOARCH=amd64 go build -v ./...
+        shell: bash
+      - name: Build ARM64
+        run: GOARCH=arm64 go build -v ./...
         shell: bash
       - name: Install socat
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Also enable explicit ARM64 builds.
This fixes the issue with `Error: enumerator/enumerator.go:31:9: undefined: nativeGetDetailedPortsLis` on MacOS/Darwin builds