### PR TITLE
fix port.Read will returns PortClosed error on linux if the buffer size is zero

### DIFF
--- a/serial_unix.go
+++ b/serial_unix.go
@@ -57,6 +57,10 @@ func (port *unixPort) Close() error {
 }
 
 func (port *unixPort) Read(p []byte) (int, error) {
+	// If the buffer is empty, instantly returns instead of returns with PortClosed error later
+	if len(p) == 0 {
+		return 0, nil
+	}
 	port.closeLock.RLock()
 	defer port.closeLock.RUnlock()
 	if atomic.LoadUint32(&port.opened) != 1 {


### PR DESCRIPTION
I was confused of the return error when I did `buf := make([]byte, 0, 1024)` :/