### PR TITLE
Port enumeration on Windows

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -19,6 +19,7 @@ package serial
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -352,7 +353,9 @@ func createOverlappedEvent() (*windows.Overlapped, error) {
 }
 
 func nativeOpen(portName string, mode *Mode) (*windowsPort, error) {
-	portName = "\\\\.\\" + portName
+	if !strings.HasPrefix(portName, `\\.\`) {
+		portName = `\\.\` + portName
+	}
 	path, err := windows.UTF16PtrFromString(portName)
 	if err != nil {
 		return nil, err

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -45,12 +45,22 @@ func nativeGetPortsList() ([]string, error) {
 	}
 	defer key.Close()
 
-	list, err := key.ReadValueNames(0)
+	names, err := key.ReadValueNames(0)
 	if err != nil {
 		return nil, &PortError{code: ErrorEnumeratingPorts, causedBy: err}
 	}
 
-	return list, nil
+	var values []string
+	for _, n := range names {
+		v, _, err := key.GetStringValue(n)
+		if err != nil || v == "" {
+			continue
+		}
+
+		values = append(values, v)
+	}
+
+	return values, nil
 }
 
 func (port *windowsPort) Close() error {


### PR DESCRIPTION
v1.6.3 breaks serial port enumeration by reading registry value names instead of registry values as it was in <=v1.6.2.

![image](https://github.com/user-attachments/assets/2bf3c193-5e47-4a9d-908a-3fa190e1a25d)

This results in `GetPortsList()` function returning `\\Device\\USBSER001`, etc. instead of `COMXX`.

This pull request fixes `nativeGetPortsList` to read the actual values, which is consistent with previous versions.

It also modifies `nativeOpen` to check for if the port name has `\\.\` prefix, which was previously added unconditionally, which caused open to fail if the port name already had that prefix.
