### PR TITLE
fix: incorrect masks for modem status bits on Windows

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -282,10 +282,10 @@ func (port *windowsPort) SetRTS(rts bool) error {
 
 // GetCommModemStatus constants. See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcommmodemstatus.
 const (
-	msCTSOn  = 0x0010
-	msDSROn  = 0x0020
-	msRingOn = 0x0040
-	msRLSDOn = 0x0080
+	MS_CTS_ON  = 0x0010
+	MS_DSR_ON  = 0x0020
+	MS_RING_ON = 0x0040
+	MS_RLSD_ON = 0x0080
 )
 
 func (port *windowsPort) GetModemStatusBits() (*ModemStatusBits, error) {
@@ -294,10 +294,10 @@ func (port *windowsPort) GetModemStatusBits() (*ModemStatusBits, error) {
 		return nil, &PortError{}
 	}
 	return &ModemStatusBits{
-		CTS: (bits & msCTSOn) != 0,
-		DCD: (bits & msRLSDOn) != 0,
-		DSR: (bits & msDSROn) != 0,
-		RI:  (bits & msRingOn) != 0,
+		CTS: (bits & MS_CTS_ON) != 0,
+		DCD: (bits & MS_RLSD_ON) != 0,
+		DSR: (bits & MS_DSR_ON) != 0,
+		RI:  (bits & MS_RING_ON) != 0,
 	}, nil
 }
 

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -280,15 +280,14 @@ func (port *windowsPort) SetRTS(rts bool) error {
 	return nil
 }
 
-// GetCommModemStatus constants. See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcommmodemstatus.
-const (
-	MS_CTS_ON  = 0x0010
-	MS_DSR_ON  = 0x0020
-	MS_RING_ON = 0x0040
-	MS_RLSD_ON = 0x0080
-)
-
 func (port *windowsPort) GetModemStatusBits() (*ModemStatusBits, error) {
+	// GetCommModemStatus constants. See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcommmodemstatus.
+	const (
+		MS_CTS_ON  = 0x0010
+		MS_DSR_ON  = 0x0020
+		MS_RING_ON = 0x0040
+		MS_RLSD_ON = 0x0080
+	)
 	var bits uint32
 	if err := windows.GetCommModemStatus(port.handle, &bits); err != nil {
 		return nil, &PortError{}

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -280,16 +280,24 @@ func (port *windowsPort) SetRTS(rts bool) error {
 	return nil
 }
 
+// GetCommModemStatus constants. See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcommmodemstatus.
+const (
+	msCTSOn  = 0x0010
+	msDSROn  = 0x0020
+	msRingOn = 0x0040
+	msRLSDOn = 0x0080
+)
+
 func (port *windowsPort) GetModemStatusBits() (*ModemStatusBits, error) {
 	var bits uint32
 	if err := windows.GetCommModemStatus(port.handle, &bits); err != nil {
 		return nil, &PortError{}
 	}
 	return &ModemStatusBits{
-		CTS: (bits & windows.EV_CTS) != 0,
-		DCD: (bits & windows.EV_RLSD) != 0,
-		DSR: (bits & windows.EV_DSR) != 0,
-		RI:  (bits & windows.EV_RING) != 0,
+		CTS: (bits & msCTSOn) != 0,
+		DCD: (bits & msRLSDOn) != 0,
+		DSR: (bits & msDSROn) != 0,
+		RI:  (bits & msRingOn) != 0,
 	}, nil
 }
 
@@ -366,7 +374,8 @@ func nativeOpen(portName string, mode *Mode) (*windowsPort, error) {
 		0, nil,
 		windows.OPEN_EXISTING,
 		windows.FILE_FLAG_OVERLAPPED,
-		0)
+		0,
+	)
 	if err != nil {
 		switch err {
 		case windows.ERROR_ACCESS_DENIED:


### PR DESCRIPTION
Fixes #204.

Bring back constants from #187 and revert the code in `GetModemStatusBits` to fix data gathering.

Ideally, this enum should get added to `golang.org/x/sys/windows` as @twpayne did for other constants.