### PR TITLE
fix: Support building on unsupported Unix systems.

### DIFF
--- a/enumerator_unsupported_unix.go
+++ b/enumerator_unsupported_unix.go
@@ -1,0 +1,17 @@
+//
+// Copyright 2014-2024 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+//go:build !linux && !darwin && !freebsd && !openbsd
+
+package serial
+
+import (
+	"errors"
+)
+
+func nativeGetPortsList() ([]string, error) {
+	return nil, errors.New("nativeGetPortsList is not currently supported on this OS")
+}

--- a/serial_unsupported_unix.go
+++ b/serial_unsupported_unix.go
@@ -1,0 +1,17 @@
+//
+// Copyright 2014-2024 Cristian Maglie. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+
+//go:build !linux && !darwin && !freebsd && !openbsd
+
+package serial
+
+import (
+        "errors"
+)
+
+func nativeOpen(portName string, mode *Mode) (Port, error) {
+	return nil, errors.New("nativeOpen is not currently supported on this OS")
+}


### PR DESCRIPTION
This adds stubs for unsupported Unix systems to allow this module to at least build.

Obviously it would be better to actually support them, and I hope to do that for illumos at some point, but this is currently a blocker for building other software such as telegraf that has an indirect dependency on go-serial, despite not requiring serial port access.

Thanks.