### PR TITLE
fix: return PortError for read timeouts in Unix and Windows serial ports

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -165,6 +165,8 @@ const (
 	PortClosed
 	// FunctionNotImplemented the requested function is not implemented
 	FunctionNotImplemented
+	// ReadTimeout the read operation timed out
+	ReadTimeout
 )
 
 // EncodedErrorString returns a string explaining the error code
@@ -194,6 +196,8 @@ func (e PortError) EncodedErrorString() string {
 		return "Port has been closed"
 	case FunctionNotImplemented:
 		return "Function not implemented"
+	case ReadTimeout:
+		return "Read operation timed out"
 	default:
 		return "Other error"
 	}

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -90,7 +90,7 @@ func (port *unixPort) Read(p []byte) (int, error) {
 		}
 		if !res.IsReadable(port.handle) {
 			// Timeout happened
-			return 0, nil
+			return 0, &PortError{code: ReadTimeout}
 		}
 		n, err := unix.Read(port.handle, p)
 		if err == unix.EINTR {

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -108,7 +108,7 @@ func (port *windowsPort) Read(p []byte) (int, error) {
 		hasTimeout := port.hasTimeout
 		port.mu.Unlock()
 		if hasTimeout {
-			return 0, nil
+			return 0, &PortError{code: ReadTimeout}
 		}
 	}
 }


### PR DESCRIPTION
## Explicit ReadTimeout Error for bufio.Reader Support

### Summary
This PR ensures that read timeout errors are explicitly returned as `PortError{code: ReadTimeout}`, enabling proper timeout tracking.

### Example Usage

```go
port, _ := serial.Open("/dev/ttyUSB0", &serial.Mode{})
port.SetReadTimeout(1 * time.Second)
reader := bufio.NewReader(port)

for {
    line, err := reader.ReadLine()
    if err != nil {
        if portErr, ok := err.(*serial.PortError); ok {
            if portErr.Code() == serial.ReadTimeout {
                // Timeout occurred - check for buffered data
                if reader.Buffered() > 0 {
                    continue // Process buffered data
                }
                // No data available, timeout is expected
                continue
            }
        }
        // Other error occurred
        return err
    }
    // Process line
}
```

### Related
This change improves integration with `bufio.Reader` by making timeout errors explicitly identifiable. Without it bufio.Reader  returns error about multiple empty reads.

