### PR TITLE
Support last two major Go versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module go.bug.st/serial
 
-go 1.26.0
+go 1.25.0
 
 require golang.org/x/sys v0.43.0


### PR DESCRIPTION
The Go directive in go.mod specifies the minimum Golang version required to run the library. Update #216 bumped this version to 1.26, making impossible to run the library with an older one. I propose to mimic the behavior of official Golang libraries and support the last 2 major Go versions, which are the ones that are receiving security updates.

Reference: https://github.com/golang/go/wiki/Go-Release-Cycle/617e4e5747d4878147b89aef6d48479fffe48c3a#release-maintenance