### PR TITLE
darwin: Fixed USB string report from port enumerator (some strings may be "normalized")

### DIFF
--- a/enumerator/usb_darwin.go
+++ b/enumerator/usb_darwin.go
@@ -113,9 +113,9 @@ func extractPortInfo(service io_registry_entry_t) (*PortDetails, error) {
 		// It's an IOUSBDevice
 		vid, _ := usbDevice.GetIntProperty("idVendor", C.kCFNumberSInt16Type)
 		pid, _ := usbDevice.GetIntProperty("idProduct", C.kCFNumberSInt16Type)
-		serialNumber, _ := usbDevice.GetStringProperty("USB Serial Number")
-		vendor, _ := usbDevice.GetStringProperty("USB Vendor Name")
-		product, _ := usbDevice.GetStringProperty("USB Product Name")
+		serialNumber, _ := usbDevice.GetStringProperty("kUSBSerialNumberString")
+		vendor, _ := usbDevice.GetStringProperty("kUSBVendorString")
+		product, _ := usbDevice.GetStringProperty("kUSBProductString")
 		configuration, _ := usbDevice.GetUSBConfigurationString()
 
 		port.IsUSB = true


### PR DESCRIPTION
The strings in the IORegistry corresponding to keys:

- `USB Serial Number`
- `USB Vendor Name`
- `USB Product Name`

are the "normalized" version of the real USB strings. The "normalization" may convert some characters into another, for example, the dash `-` is converted into an underscore `_`.

The original strings are, instead, available at the following properties, respectively:

- `kUSBSerialNumberString`
- `kUSBVendorString`
- `kUSBProductString`